### PR TITLE
Correctly correspond to pthread_ kill

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -71,7 +71,7 @@ LIBIMOBILEDEVICE_GLUE_API int thread_alive(THREAD_T thread)
 	if (!thread)
 		return 0;
 #ifdef WIN32
-	return WaitForSingleObject(thread, 0) == WAIT_TIMEOUT;
+	return TerminateThread(thread, 0);
 #else
 	return pthread_kill(thread, 0) == 0;
 #endif


### PR DESCRIPTION
Sometimes WaitForSingleObject cannot be returned due to thread exceptions.
TerminateThread can force the thread to end.