### PR TITLE
Wrong conditional judgment

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -275,7 +275,7 @@ LIBIMOBILEDEVICE_GLUE_API int buffer_read_from_filename(const char *filename, ch
 
 	*buffer = (char*)malloc(sizeof(char)*(size+1));
 
-	if (!(*buffer)) {
+	if (*buffer == NULL) {
 		return 0;
 	}
 


### PR DESCRIPTION
Modify the wrong judgment, and the original condition is always false