### PR TITLE
Ignore IDE files and macOS finder info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ py-compile
 stamp-h1
 src/.libs
 src/libimobiledevice-glue-1.0.pc
+.idea/
+.DS_Store
+.vscode/


### PR DESCRIPTION
Makes it so that we have less untracked files when using an IDE