### PR TITLE
Add missing package to dependencies list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sudo apt-get install \
 	automake \
 	libtool-bin \
 	libplist-dev \
+	pkg-config \
 ```
 
 Then clone the actual project repository:


### PR DESCRIPTION
While building this on Debian 11, I noticed that this couldn't build unless I either removed the package check for libplist or installed pkg-config. I added pkg-config to the dependencies list so others wouldn't run into this issue.