### PR TITLE
socket: select returns 1 when the socket is closed

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -1223,10 +1223,19 @@ LIBIMOBILEDEVICE_GLUE_API int socket_receive_timeout(int fd, void *data, size_t 
 
 LIBIMOBILEDEVICE_GLUE_API int socket_send(int fd, void *data, size_t length)
 {
+	char buffer[1] = {0};
 	int flags = 0;
 	int res = socket_check_fd(fd, FDM_WRITE, SEND_TIMEOUT);
 	if (res <= 0) {
 		return res;
+	}
+	res = socket_check_fd(fd, FDM_READ, 1);
+	if (res > 0) {
+		if (recv(fd, buffer, 1, MSG_PEEK) <= 0) {
+			fprintf(stderr, "%s: fd=%d closed\n", __func__, fd);
+			errno = EIO;
+			return -EIO;
+		}
 	}
 #ifdef MSG_NOSIGNAL
 	flags |= MSG_NOSIGNAL;


### PR DESCRIPTION
On Windows, when I quickly unplug the device. 
Sometimes it gets stuck in send().
The reason is that when the peer (driver) closes the socket, select returns a value of 1.
So I use very little time to check if the current is readable.
If the read data is less than or equal to 0, the socket is closed. 
We don't need to send, because continuing the operation will prevent the thread from returning and continue to consume CPU resources. 