### PR TITLE
Occasionally blocks in send() when device is disconnected quickly.

### DIFF
--- a/include/libimobiledevice-glue/socket.h
+++ b/include/libimobiledevice-glue/socket.h
@@ -62,6 +62,7 @@ int socket_send(int fd, void *data, size_t length);
 int socket_get_socket_port(int fd, uint16_t *port);
 
 void socket_set_verbose(int level);
+void socket_set_check_disconnect(int check);
 
 const char *socket_addr_to_string(struct sockaddr *addr, char *addr_out, size_t addr_out_size);
 


### PR DESCRIPTION
If usbmuxd notifies the device to disconnect, but the application is sending data, it may cause blocking in socket_send() .
When running on Windows, this bug occurs sporadically with high frequency.
So I added an interface that might help some applications.
And, if you ignore this interface, it will not affect the original logic.