### PR TITLE
Include stdio.h

### DIFF
--- a/include/libimobiledevice-glue/termcolors.h
+++ b/include/libimobiledevice-glue/termcolors.h
@@ -24,6 +24,7 @@
 #include "config.h"
 #endif
 
+#include <stdio.h>
 #include <stdarg.h>
 
 #define COLOR_RESET           "\e[m"


### PR DESCRIPTION
When trying to compile the library files as a swift package to expose the API to swift, you will get an error message, that `stdio.h` must be included in `termcolors.h`, since `FILE` is defined in `stdio.h`.  The error says:

```
Declaration of 'FILE' must be imported from module 'Darwin.C._stdio' before it is required
```

The error does only appear if you try to import the generated module inside of swift. This change should not break any existing functionality and it would help with compiling the project as a swift module. Is there any reason not to include ` stdio.h` ? You can find an example swift module [here](https://github.com/Schlaubischlump/CImobileDeviceGlue). You would still need to add a test target, that imports the module and remove the `#include <stdio.h>` line that I added to my fork, to reproduce the error. 