### PR TITLE
Fixed 32bit buffer overflow

### DIFF
--- a/src/opack.c
+++ b/src/opack.c
@@ -206,7 +206,7 @@ static void opack_encode_node(plist_t node, struct char_buf* cbuf)
 						if (len >> 32) {
 							uint8_t blen = 0x94;
 							char_buf_append(cbuf, 1, &blen);
-							uint32_t u64val = htole64(len);
+							uint64_t u64val = htole64(len);
 							char_buf_append(cbuf, 8, (unsigned char*)&u64val);
 						} else {
 							uint8_t blen = 0x93;


### PR DESCRIPTION
Fixed issue where 32 bit buffer is used to store a 64 bit value resulting in truncation.

8 bytes from the 32 bit buffer is subsequently read, resulting in four unrelated adjacent bytes being used in the resultant structure