### PR TITLE
Improve portability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ PKG_CHECK_MODULES(libplist, libplist-2.0 >= $LIBPLIST_VERSION)
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h])
+AC_CHECK_HEADERS([netpacket/packet.h net/if_dl.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/src/utils.c
+++ b/src/utils.c
@@ -220,7 +220,7 @@ char *string_toupper(char* str)
 	char *res = strdup(str);
 	size_t i;
 	for (i = 0; i < strlen(res); i++) {
-		res[i] = toupper(res[i]);
+		res[i] = toupper((unsigned char)res[i]);
 	}
 	return res;
 }


### PR DESCRIPTION
The primary purpose of these changes is for compatibility with NetBSD, but nothing is NetBSD-specific.